### PR TITLE
Change Portainer Image from Enterprise to Commercial edition

### DIFF
--- a/monitoring/kubernetes-dashboards/portainer.yaml
+++ b/monitoring/kubernetes-dashboards/portainer.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     app.kubernetes.io/name: portainer
     app.kubernetes.io/instance: portainer
-    app.kubernetes.io/version: "ce-latest-ee-2.19.4"
+    app.kubernetes.io/version: "ce-latest-ce-2.20.3"
 ---
 # Source: portainer/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: portainer
     app.kubernetes.io/instance: portainer
-    app.kubernetes.io/version: "ce-latest-ee-2.19.4"
+    app.kubernetes.io/version: "ce-latest-ce-2.20.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -41,7 +41,7 @@ metadata:
     io.portainer.kubernetes.application.stack: portainer
     app.kubernetes.io/name: portainer
     app.kubernetes.io/instance: portainer
-    app.kubernetes.io/version: "ce-latest-ee-2.19.4"
+    app.kubernetes.io/version: "ce-latest-ce-2.20.3"
 spec:
   type: LoadBalancer
   selector:
@@ -75,7 +75,7 @@ spec:
       serviceAccountName: portainer-sa-clusteradmin
       containers:
       - name: portainer
-        image: "portainer/portainer-ee:2.19.4"
+        image: "portainer/portainer-ce:2.20.3"
         imagePullPolicy: Always
         ports:
         - containerPort: 9000


### PR DESCRIPTION
Currently the image being used is "portainer-**ee**:2.19.4". The "ee" stands for Enterprise Edition which they also call as Business Edition (BE) whcih requires a license when deployed as shown below:


![portainer-ee-license](https://github.com/alanrenouf/ECSExample/assets/23652676/b4bc3d5c-1886-466f-ad0c-86bab766a146)

Portainer also has a "ce" image which stands for Community Edition which does not require a license. As we're using portainer for demo purpose, the "ce" image should suffice and avoids users need to register with portainer to obtain a license.

More info on difference between CE and EE/BE: https://www.portainer.io/blog/portainer-community-edition-ce-vs-portainer-business-edition-be-whats-the-difference

Latest CE Image can be found here: https://hub.docker.com/r/portainer/portainer-ce

I have deployed and tested the image "portainer-ce:2.20.3". Screenshots below:

<img width="853" alt="image" src="https://github.com/alanrenouf/ECSExample/assets/23652676/0ecd9016-46f6-4db7-9a10-6a735457a7eb">

<img width="374" alt="image" src="https://github.com/alanrenouf/ECSExample/assets/23652676/b2c9a26a-a846-4dce-ae10-a539a8906e08">

Output:

![image](https://github.com/alanrenouf/ECSExample/assets/23652676/285b30e9-a0ea-4a5e-8cf9-5465a6b8fad4)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Updated the Portainer image in the Kubernetes deployment configuration to use the Community Edition instead of the Enterprise Edition, eliminating the need for a license for demo purposes.

- **Deployment**:
    - Changed the Portainer image from the Enterprise Edition (portainer-ee:2.19.4) to the Community Edition (portainer-ce:2.20.3) in the Kubernetes deployment configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->